### PR TITLE
Fix parameter imenu-list-update

### DIFF
--- a/leaf-tree.el
+++ b/leaf-tree.el
@@ -233,7 +233,7 @@ See `insert-entries-internal'."
   (pcase-dolist (`(,sym . ,fn) leaf-tree-advice-alist)
     (advice-add sym :around fn))
   (imenu-list-minor-mode)
-  (imenu-list-update nil 'force))
+  (imenu-list-update 'force))
 
 (defun leaf-tree--teardown ()
   "Teardown leaf-tree."


### PR DESCRIPTION
Fix the arguments of the imenu-list-update function.

- old version imenu-list-update require three arguments, but current version imenu-list-update require two arguments.
https://github.com/bmag/imenu-list/commit/6ffd9b303a7de7196e59b55ca7bb41fa6f38038b#diff-31905d01e0258e0f24319e4cd9[…]7312bea8d94a50454782d53a779L483

Related Issue: https://github.com/conao3/leaf-tree.el/issues/4