### PR TITLE
Update GitHub Actions to modern configuration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,34 +1,40 @@
-name: Main workflow
-on: [push, pull_request]
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         emacs_version:
-          - '25.1'
-          - '25.2'
-          - '25.3'
-          - '26.1'
-          - '26.2'
-          - '26.3'
+          - '27.1'
+          - '27.2'
+          - '28.1'
+          - '28.2'
+          - '29.1'
+          - '29.2'
+          - '29.3'
+          - '29.4'
           - 'snapshot'
-        include:
-          - emacs_version: 'snapshot'
-            allow_failure: true
+
     steps:
-    - uses: actions/checkout@v1
-    - uses: actions/setup-python@v1.1.1
-    - uses: purcell/setup-emacs@master
-      with:
-        version: ${{ matrix.emacs_version }}
-    - uses: conao3/setup-cask@master
+      - uses: actions/checkout@v4
 
-    - name: Run tests
-      if: matrix.allow_failure != true
-      run: 'make test'
+      - uses: jcs090218/setup-emacs@master
+        with:
+          version: ${{ matrix.emacs_version }}
 
-    - name: Run tests (allow failure)
-      if: matrix.allow_failure == true
-      run: 'make test || true'
+      - uses: conao3/setup-cask@master
+
+      - name: Install dependencies
+        run: cask install
+
+      - name: Run tests
+        run: make test
+        continue-on-error: ${{ matrix.emacs_version == 'snapshot' }}


### PR DESCRIPTION
- Upgrade actions/checkout from v1 to v4
- Replace deprecated purcell/setup-emacs with jcs090218/setup-emacs
- Remove unnecessary actions/setup-python dependency
- Update Emacs versions from 25.x-26.x to 27.x-29.x
- Add explicit cask install step
- Use continue-on-error instead of manual allow_failure pattern
- Add fail-fast: false for complete test matrix results
- Restrict triggers to master branch