### PR TITLE
chore: update dependencies

### DIFF
--- a/README.org
+++ b/README.org
@@ -18,7 +18,7 @@ leaf-tree provides a tree-view sidebar that displays all your =leaf= declaration
 * Requirements
 
 - Emacs 25.1 or later
-- [[https://github.com/bmag/imenu-list][imenu-list]] 0.8 or later
+- [[https://github.com/bmag/imenu-list][imenu-list]] 0.9 or later
 
 * Installation
 

--- a/leaf-tree.el
+++ b/leaf-tree.el
@@ -5,7 +5,7 @@
 ;; Author: Naoya Yamashita <conao3@gmail.com>
 ;; Version: 1.0.0
 ;; Keywords: convenience leaf
-;; Package-Requires: ((emacs "25.1") (imenu-list "0.8"))
+;; Package-Requires: ((emacs "25.1") (imenu-list "0.9"))
 ;; URL: https://github.com/conao3/leaf-tree.el
 
 ;; This program is free software: you can redistribute it and/or modify


### PR DESCRIPTION
## Summary

Modernize dependencies to their latest versions.

- Bump `imenu-list` requirement from `0.8` to `0.9` (latest release) in `Package-Requires` and the README requirements.

## Notes

- This is an Emacs Lisp / Cask project. The only third-party runtime dependency is `imenu-list`; the development dependency `cort` (Cask) is unpinned and already resolves to the latest version. There is no lockfile to update (Cask has none; `.cask/` is gitignored cache).
- The `emacs` floor (`25.1`) was intentionally left unchanged: it is a minimum-supported-runtime declaration rather than a fetched dependency, and raising it would drop support for older Emacs users without benefit. The code uses no constructs requiring a newer Emacs.
- GitHub Actions (`actions/checkout@v6`, `jcs090218/setup-emacs@master`, `conao3/setup-cask@master`) already track the latest versions; no change needed.

## Test plan

- [x] `cask install` resolves dependencies with the bumped requirement
- [x] `make build` compiles cleanly (no new warnings)
- [x] `make test` passes (exit 0) on Emacs 29.3

https://claude.ai/code/session_01GGBpFzoYm48AvLB295jyZT

---
_Generated by [Claude Code](https://claude.ai/code/session_01GGBpFzoYm48AvLB295jyZT)_